### PR TITLE
第11章(4) 本番環境でSendGridを使用する設定を追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,8 +61,8 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
-  host = 'https://s-rails-sample-app.herokuapp.com'
-  config.action_mailer.default_url_options = { host: host }
+  host = 's-rails-sample-app.herokuapp.com'
+  config.action_mailer.default_url_options = { host: host, protocol: 'https' }
   ActionMailer::Base.smtp_settings = {
     address: 'smtp.sendgrid.net',
     port: '587',

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,7 +59,19 @@ Rails.application.configure do
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  host = 'https://s-rails-sample-app.herokuapp.com'
+  config.action_mailer.default_url_options = { host: host }
+  ActionMailer::Base.smtp_settings = {
+    address: 'smtp.sendgrid.net',
+    port: '587',
+    authentication: :plain,
+    user_name: ENV['SENDGRID_USERNAME'],
+    password: ENV['SENDGRID_PASSWORD'],
+    domain: 'heroku.com',
+    enable_starttls_auto: true
+  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
## 目的
本番環境でSendGridを使用する

## レビュアー
こーめいくん

## 内容
production環境でメール送信のためのSendGridを使用できるよう設定

## レビューポイント
[第11章](https://github.com/shizunaito/rails-tutorial/pull/14)のコミットにもれがあったので追加しました 🙇 

大変お手数ですがレビューお願いいたします 🙇 
