### PR TITLE
ユーザーの情報をJsonで返す

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,16 @@ class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
     @microposts = @user.microposts.paginate(page: params[:page])
-    redirect_to root_url and return unless @user.activated?
+    data = { id: @user.id,
+             name: @user.name,
+             following: @user.following.count,
+             followers: @user.followers.count,
+             microposts: @microposts
+           }
+    respond_to do |format|
+      format.html { redirect_to root_url and return unless @user.activated? }
+      format.json { render json: data }
+    end
   end
 
   def new

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,4 +21,13 @@ Rails.application.routes.draw do
   resources :password_resets, only: [:new, :create, :edit, :update]
   resources :microposts, only: [:create, :destroy]
   resources :relationships, only: [:create, :destroy]
+
+  scope :api, format: 'json' do
+    resources :users do
+      member do
+        get :following, :followers
+      end
+    end
+    resources :microposts, only: [:create, :destroy]
+  end
 end


### PR DESCRIPTION
## 目的
- JsonAPI用のルーティングを追加
- ユーザー情報をjsonで取得

## レビュアー
- えんどうくん
- sunさん

## 内容
- routesにJsonAPI用のapiスコープを追加
- ユーザー情報を下記の通り取得できるようにした

endpoint：`/api/users/2`
```
{
  "id": 2,
  "name": "Oral Bechtelar",
  "following": 0,
  "followers": 0,
  "microposts": [
    {
      "id": 296,
      "content": "Odit nihil aut expedita consequatur.",
      "user_id": 2,
      "created_at": "2017-07-19T06:29:11.379Z",
      "updated_at": "2017-07-19T06:29:11.379Z",
      "picture": {
        "url": null
      }
    },
    ... 
}
```

## レビューポイント
jsonで返すデータの構造をshowメソッドにもたせたのですが、
この方法がいいのかわからないのでその部分を特にみていただきたいです。