### PR TITLE
JSON形式で返す際にjbuilderを使用するよう変更

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,15 +11,9 @@ class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
     @microposts = @user.microposts.paginate(page: params[:page])
-    data = { id: @user.id,
-             name: @user.name,
-             following: @user.following.count,
-             followers: @user.followers.count,
-             microposts: @microposts
-           }
     respond_to do |format|
       format.html { redirect_to root_url and return unless @user.activated? }
-      format.json { render json: data }
+      format.json
     end
   end
 

--- a/app/views/users/show.json.jbuilder
+++ b/app/views/users/show.json.jbuilder
@@ -1,0 +1,8 @@
+json.(@user, :id, :name)
+
+json.following @user.following.count
+json.followers @user.followers.count
+
+json.microposts @microposts do |micropost|
+  json.(micropost, :id, :content, :created_at, :updated_at, :picture)
+end

--- a/app/views/users/show.json.jbuilder
+++ b/app/views/users/show.json.jbuilder
@@ -4,5 +4,5 @@ json.following @user.following.count
 json.followers @user.followers.count
 
 json.microposts @microposts do |micropost|
-  json.(micropost, :id, :content, :created_at, :updated_at, :picture)
+  json.merge! micropost.attributes.except('user_id')
 end


### PR DESCRIPTION
## 目的
- Userデータをshow.json.jbuilderにもたせるように修正

## レビュアー
sunさん

### 経緯
もともとUsersコントローラのshowメソッドにJSONのデータ形式をもたせていたが、
コントローラで形式を指定するのに違和感があったのでsunさんに相談した。

- コントローラにもたせてるとMVCの切り分けが曖昧になってきている
- 今は`data = { ... }`の指定があんまり長くないけど、今後増えていったらUsersコントローラが肥大化してしまう
- jbuilder使うと`views`にJSONの表示部分を置けるし指定も柔軟性があって簡潔で良い

上記のような話があったので、jbuilderを使ってjsonの表示をviewsディレクトリ内で扱えるようにした。

## 内容
- `app/views/users/show.json.jbuilder`を追加
- コントローラでdataを指定していたのを削除
- 取得データを修正した
  - micropostの`user_id`は必ず`id`と一致するので返さないようにした

endpoint：`http://localhost:3000/api/users/1`
返り値
```
{
  "id": 1,
  "name": "Example User",
  "following": 49,
  "followers": 38,
  "microposts": [
    {
      "id": 295,
      "content": "Odit nihil aut expedita consequatur.",
      "created_at": "2017-07-19T06:29:11.374Z",
      "updated_at": "2017-07-19T06:29:11.374Z",
      "picture": {
        "picture": {
          "url": null
        }
      }
    },
    ...
}
```

## レビューポイント
jbuilderについて書き方が曖昧なので改善点等あればご指摘いただきたいです 🙇 
（[rails/jbuilder - Github](https://github.com/rails/jbuilder)を参考にしました）