### PR TITLE
ユーザー情報を返すエンドポイントを追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,10 @@ class UsersController < ApplicationController
     end
   end
 
+  def userinfo
+    @user = User.find(params[:id])
+  end
+
   def new
     @user = User.new
   end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -8,7 +8,7 @@ module UsersHelper
   def gravatar_url(user, options = { size: 80 })
     gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
     size = options[:size]
-    return "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
+    "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
   end
 
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -2,9 +2,13 @@ module UsersHelper
 
   # 引数で与えられたユーザーのGravatar画像を返す
   def gravatar_for(user, options = { size: 80 })
+    image_tag(gravatar_url(user, options), alt: user.name, class: "gravatar")
+  end
+
+  def gravatar_url(user, options = { size: 80 })
     gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
     size = options[:size]
-    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
-    image_tag(gravatar_url, alt: user.name, class: "gravatar")
+    return "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
   end
+
 end

--- a/app/views/users/userinfo.json.jbuilder
+++ b/app/views/users/userinfo.json.jbuilder
@@ -1,0 +1,1 @@
+json.(@user, :id, :name)

--- a/app/views/users/userinfo.json.jbuilder
+++ b/app/views/users/userinfo.json.jbuilder
@@ -1,1 +1,2 @@
 json.(@user, :id, :name)
+json.avatar gravatar_url(@user)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,10 +26,10 @@ Rails.application.routes.draw do
     resources :users do
       member do
         get :following, :followers
+        get :profile, to: 'users#userinfo'
       end
     end
     resources :microposts, only: [:create, :destroy]
     get '/random', to: 'random_feeds#show'
-    get '/user/:id', to: 'users#userinfo', as: 'userinfo'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,6 @@ Rails.application.routes.draw do
     end
     resources :microposts, only: [:create, :destroy]
     get '/random', to: 'random_feeds#show'
-    get '/user/:id', to: 'users#userinfo'
+    get '/user/:id', to: 'users#userinfo', as: 'userinfo'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,5 +30,6 @@ Rails.application.routes.draw do
     end
     resources :microposts, only: [:create, :destroy]
     get '/random', to: 'random_feeds#show'
+    get '/user/:id', to: 'users#userinfo'
   end
 end

--- a/hoge.html
+++ b/hoge.html
@@ -1,1 +1,0 @@
-{"id":2,"name":"Clarissa Boehm Sr.","image":"\u003cimg alt=\"Clarissa Boehm Sr.\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03037e249b97891693d6e292289be0ff?s=80\" /\u003e"}

--- a/hoge.html
+++ b/hoge.html
@@ -1,0 +1,1 @@
+{"id":2,"name":"Clarissa Boehm Sr.","image":"\u003cimg alt=\"Clarissa Boehm Sr.\" class=\"gravatar\" src=\"https://secure.gravatar.com/avatar/03037e249b97891693d6e292289be0ff?s=80\" /\u003e"}

--- a/test/integration/users_userinfo_test.rb
+++ b/test/integration/users_userinfo_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class UsersUserinfoTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:michael)
+  end
+
+  test "get user information through userinfo api" do
+    get userinfo_path(@user)
+    assert_match "id", response.body
+    assert_match "name", response.body
+    assert_match "Michael Example", response.body
+    assert_match "avatar", response.body
+    assert_match "gravatar", response.body
+  end
+end

--- a/test/integration/users_userinfo_test.rb
+++ b/test/integration/users_userinfo_test.rb
@@ -6,7 +6,7 @@ class UsersUserinfoTest < ActionDispatch::IntegrationTest
   end
 
   test "get user information through userinfo api" do
-    get userinfo_path(@user)
+    get profile_user_path(@user)
     assert_match "id", response.body
     assert_match "name", response.body
     assert_match "Michael Example", response.body


### PR DESCRIPTION
### 何を解決するのか
- ユーザー情報を返すエンドポイントを追加
    - 従来の `/api/users/:id` では、ユーザーのMicropostも取得してしまうことが問題だった
    - Micropostは返さず、ユーザー名とユーザーID、gravatar画像のURLのみを返すエンドポイントを追加

### 詳細
（とくになし）

### 期日
クライアントアプリにユーザー情報取得機能を追加するまで（ちょい急ぎめ）

### レビューポイント
- config/routes.rb
    - エンドポイント名、これでいいかなという気持ちがあります

### レビュアー
@shizunaito @Asuforce 
